### PR TITLE
fix(validation): add separators to valid characters

### DIFF
--- a/src/lib/urn.spec.ts
+++ b/src/lib/urn.spec.ts
@@ -80,3 +80,23 @@ test("Should parse URN and return all parts in object, but keep nid with nss if 
     nss: 'baz:foo',
   });
 });
+
+test('Should allow uuid as NID', (t) => {
+  let urn: string;
+  t.notThrows(
+    () => (urn = URN.stringify('6bddf037-c1d0-4ac9-bd0f-1b0c988e6c0e'))
+  );
+  t.is(urn, 'urn:nid:6bddf037-c1d0-4ac9-bd0f-1b0c988e6c0e');
+});
+
+test('Should allow NID with lodash', (t) => {
+  let urn: string;
+  t.notThrows(() => (urn = URN.stringify('foo_bar')));
+  t.is(urn, 'urn:nid:foo_bar');
+});
+
+test('Should allow NID with colon', (t) => {
+  let urn: string;
+  t.notThrows(() => (urn = URN.stringify('foo:bar')));
+  t.is(urn, 'urn:nid:foo:bar');
+});

--- a/src/lib/urn.ts
+++ b/src/lib/urn.ts
@@ -65,5 +65,5 @@ export class URN {
   /**
    * Checks that a string only contains characters A-Z and 0-9 (case insensitive)
    */
-  static readonly isValid = /^[a-z0-9]*$/i;
+  static readonly isValid = /^[a-z0-9_\-:]*$/i;
 }


### PR DESCRIPTION
adds separators like dash, lowdash and colon to valid characters

- **What kind of change does this PR introduce?** Bug fix

- **What is the current behavior?** UUIDs are not allowed as NSS. This change fixes that

- **What is the new behavior (if this is a feature change)?** UUIDs and other separators are allowed as NSS.
